### PR TITLE
Updated README to include information on OS X certificate requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ To run the perl clients, you'll need to install the following perl modules:
 *   LWP::UserAgent
 *   HTML::Form
 
+Note: On OS X, you'll need to install the Mozilla:CA module or set the PERL_LWP_SSL_CA_FILE environment variable to point to the CA X.509 certificates.
+
 ###Python
 To run the python clients, you'll need to have at Python version 2.7 or above installed on your system.  The scripts have been tested on 2.7 as well as Python 3.0.  You will also need the following python libraries installed:
 *   requests


### PR DESCRIPTION
On OS X, HTTPS authentication requests to _https://utslogin.nlm.nih.gov_ will not work and produce a fatal error:

```
tuna:$ perl retrieve-cui-or-code.pl -u username -p password -i C0007286
Error: 500 Can't verify SSL peers without knowing which Certificate Authorities to trust at lib/Authentication/TicketClient.pm line 36.
```

this is because _libwww-perl_ requires information about which CA SSL certificates can be trusted but this seems to be missing.

The problem is fixed by either:

a)  setting the environment variable _ PERL_LWP_SSL_CA_FILE _ to point to the certificates

b) skipping SSL peer verification by setting the environment variable _PERL_LWP_SSL_VERIFY_HOSTNAME_ to 0 

c) installing the _[Mozilla::CA](http://search.cpan.org/perldoc?Mozilla%3A%3ACA)_ Perl module 

I've just updated the README file pointing users to install the module on OS X. 

For the record, I am running perl 5.18.2 on OS X 10.11.4
